### PR TITLE
CASSANDRA-16085-3.11 WindowsTimer Fix

### DIFF
--- a/src/java/org/apache/cassandra/utils/WindowsTimer.java
+++ b/src/java/org/apache/cassandra/utils/WindowsTimer.java
@@ -35,6 +35,7 @@ public final class WindowsTimer
         try
         {
             Native.register("winmm");
+            available = true;
         }
         catch (NoClassDefFoundError e)
         {

--- a/src/java/org/apache/cassandra/utils/WindowsTimer.java
+++ b/src/java/org/apache/cassandra/utils/WindowsTimer.java
@@ -27,6 +27,8 @@ import com.sun.jna.Native;
 public final class WindowsTimer
 {
     private static final Logger logger = LoggerFactory.getLogger(WindowsTimer.class);
+    
+    private static boolean available;
 
     static
     {
@@ -37,6 +39,10 @@ public final class WindowsTimer
         catch (NoClassDefFoundError e)
         {
             logger.warn("JNA not found. winmm.dll cannot be registered. Performance will be negatively impacted on this node.");
+        }
+        catch (UnsatisfiedLinkError e)
+        {
+            logger.error("Failed to link the winmm.dll library against JNA. Performance will be negatively impacted on this node.", e);
         }
         catch (Exception e)
         {
@@ -54,6 +60,8 @@ public final class WindowsTimer
         if (period == 0)
             return;
         assert(period > 0);
+        if (!available)
+            return;
         if (timeBeginPeriod(period) != 0)
             logger.warn("Failed to set timer to : {}. Performance will be degraded.", period);
     }
@@ -63,6 +71,8 @@ public final class WindowsTimer
         if (period == 0)
             return;
         assert(period > 0);
+        if (!available)
+            return;
         if (timeEndPeriod(period) != 0)
             logger.warn("Failed to end accelerated timer period. System timer will remain set to: {} ms.", period);
     }


### PR DESCRIPTION
Add the ability to catch UnsatisfiedLinkError in WindowsTimer and if not available to allow startup to continue.

The fix implemented is similar to fix done in [CASSANDRA-13333](https://issues.apache.org/jira/browse/CASSANDRA-13333). In that issue [WindowsTimer](https://issues.apache.org/jira/browse/CASSANDRA-13333?focusedCommentId=15929959&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15929959) was mentioned but further down the question of [moving WindowsTimer](https://issues.apache.org/jira/browse/CASSANDRA-13333?focusedCommentId=15937127&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15937127) is asked so it could be fixed and answered not to move.